### PR TITLE
Fix Encoding::CompatibilityError: incompatible encoding regexp match (UTF-8 regexp with ASCII-8BIT string)

### DIFF
--- a/lib/yandex/translator.rb
+++ b/lib/yandex/translator.rb
@@ -1,3 +1,9 @@
+class JsonParser < HTTParty::Parser
+  def json
+    ::JSON.parse(body)
+  end
+end
+
 module Yandex
   class Translator
     include HTTParty

--- a/lib/yandex/translator.rb
+++ b/lib/yandex/translator.rb
@@ -1,3 +1,5 @@
+require 'httparty'
+
 class JsonParser < HTTParty::Parser
   def json
     ::JSON.parse(body)
@@ -7,6 +9,7 @@ end
 module Yandex
   class Translator
     include HTTParty
+    parser JsonParser
     base_uri 'https://translate.yandex.net/api/v1.5/tr.json'
 
     attr_reader :api_key


### PR DESCRIPTION
Hey.

I encountered error Encoding::CompatibilityError: incompatible encoding regexp match (UTF-8 regexp with ASCII-8BIT string) when I wanted to translate text that includes special characters.

`translator.translate 'Car', from: 'ru'`
=> 
`Encoding::CompatibilityError: incompatible encoding regexp match (UTF-8 regexp with ASCII-8BIT string)
	from /home/pnc/.rvm/gems/ruby-2.4.0/gems/httparty-0.15.3/lib/httparty/parser.rb:120:in `gsub'`

According to @ericgj from [this post](https://github.com/jnunemaker/httparty/issues/75) that fixed this problem.

ruby 2.4.0p0
httparty (0.15.3, 0.15.2)
 