### PR TITLE
Fix Encoding::CompatibilityError: incompatible encoding regexp match …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ lib/bundler/man
 pkg
 rdoc
 spec/reports
+spec/secrets.yml
 test/tmp
 test/version_tmp
 tmp

--- a/lib/yandex/translator.rb
+++ b/lib/yandex/translator.rb
@@ -1,6 +1,15 @@
+
 module Yandex
+
+  class JsonParser < HTTParty::Parser
+    def json
+      ::JSON.parse(body)
+    end
+  end
+
   class Translator
     include HTTParty
+    parser JsonParser
     base_uri 'https://translate.yandex.net/api/v1.5/tr.json'
 
     attr_reader :api_key

--- a/spec/lib/yandex/translator_spec.rb
+++ b/spec/lib/yandex/translator_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'vcr'
 
 describe Yandex::Translator do
   let(:api_key) { 'secret' }

--- a/spec/lib/yandex/translator_vcr_spec.rb
+++ b/spec/lib/yandex/translator_vcr_spec.rb
@@ -1,0 +1,90 @@
+require 'spec_helper'
+require 'vcr'
+
+describe Yandex::Translator do
+  let(:api_key) { RSpec.configuration.yandex_api_key }
+  subject(:translator) { Yandex::Translator.new(api_key) }
+
+  describe '::translate' do
+    before do
+      expect_any_instance_of(Yandex::Translator).to receive(:translate)
+      Yandex::Translator.api_key = api_key
+    end
+  end
+
+  describe '#translate' do
+    it 'returns ru translalation ' do
+      VCR.use_cassette('get_translated_ru_text') do
+        response = translator.translate('Car', 'ru')
+        expect(response).to eq("Автомобиль")
+      end
+    end
+
+    it 'returns pl translalation' do
+      VCR.use_cassette('get_translated_pl_text') do
+        response = translator.translate('Car', 'pl')
+        expect(response).to eq("Samochód")
+      end
+    end
+
+    it 'accepts options' do
+      VCR.use_cassette('accepts options') do
+        response = translator.translate('Car', from: :ru)
+        expect(response).to eq("Автомобиль")
+      end
+    end
+
+    context 'with two languages' do
+      it 'accepts options' do
+        VCR.use_cassette('accepts options') do
+          response = translator.translate('Samochód', from: :pl, to: :ru)
+          expect(response).to eq("Автомобиль")
+        end
+      end
+
+      it 'accepts languages list' do
+        VCR.use_cassette('accepts options') do
+          response = translator.translate('Car', :ru, :en)
+          expect(response).to eq("Автомобиль")
+        end
+      end
+    end
+
+    context 'with wrong api key' do
+      let(:wrong_translator) { Yandex::Translator.new('wrong_api_key') }
+
+      it 'returns translation error' do
+        expect{
+          VCR.use_cassette('wrong_api_key') do
+            wrong_translator.translate('Car', :ru, :en)
+          end
+        }.to raise_error(Yandex::ApiError, "API key is invalid")
+      end
+    end
+  end
+
+  describe '#detect' do
+    let(:detected_translation) {
+      VCR.use_cassette('#detect') do
+        translator.detect('Car')
+      end
+    }
+
+    it 'returns detected language' do
+      expect(detected_translation).to eq 'en'
+    end
+  end
+
+  describe '#langs' do
+    let(:list_of_langs) {
+      VCR.use_cassette('#langs') do
+        translator.langs
+      end
+    }
+
+    it 'returns array of dirs' do
+      expect(list_of_langs).to include 'en-ru', 'uk-pl', 'pl-ru'
+    end
+
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,20 @@
 require 'rspec'
 require 'yandex-translator'
 require 'webmock/rspec'
-include WebMock
+require 'vcr'
+include WebMock::API
 
 RSpec.configure do |config|
+  if File.exists? ('spec/secrets.yml')
+    YANDEX_API_KEY = YAML.load_file('spec/secrets.yml')
+  else
+    YANDEX_API_KEY = {}
+  end
+  config.add_setting :yandex_api_key, :default => YANDEX_API_KEY['yandex_translator_api_key']
+end
 
+VCR.configure do |c|
+  c.cassette_library_dir = 'spec/vcr'
+  c.hook_into :webmock
+  c.filter_sensitive_data('<YANDEX_API_KEY>') { RSpec.configuration.yandex_api_key }
 end

--- a/spec/vcr/_detect.yml
+++ b/spec/vcr/_detect.yml
@@ -1,0 +1,42 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://translate.yandex.net/api/v1.5/tr.json/detect
+    body:
+      encoding: UTF-8
+      string: text=Car&key=<YANDEX_API_KEY>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.2
+      Date:
+      - Fri, 19 May 2017 10:25:21 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '24'
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - timeout=120
+      Cache-Control:
+      - no-store
+      X-Content-Type-Options:
+      - nosniff
+    body:
+      encoding: UTF-8
+      string: '{"code":200,"lang":"en"}'
+    http_version: 
+  recorded_at: Fri, 19 May 2017 10:25:21 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/_langs.yml
+++ b/spec/vcr/_langs.yml
@@ -1,0 +1,40 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://translate.yandex.net/api/v1.5/tr.json/getLangs
+    body:
+      encoding: UTF-8
+      string: key=<YANDEX_API_KEY>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.2
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - timeout=120
+      Date:
+      - Fri, 19 May 2017 10:25:21 GMT
+      X-Content-Type-Options:
+      - nosniff
+    body:
+      encoding: ASCII-8BIT
+      string: '{"dirs":["az-ru","be-bg","be-cs","be-de","be-en","be-es","be-fr","be-it","be-pl","be-ro","be-ru","be-sr","be-tr","bg-be","bg-ru","bg-uk","ca-en","ca-ru","cs-be","cs-en","cs-ru","cs-uk","da-en","da-ru","de-be","de-en","de-es","de-fr","de-it","de-ru","de-tr","de-uk","el-en","el-ru","en-be","en-ca","en-cs","en-da","en-de","en-el","en-es","en-et","en-fi","en-fr","en-hu","en-it","en-lt","en-lv","en-mk","en-nl","en-no","en-pt","en-ru","en-sk","en-sl","en-sq","en-sv","en-tr","en-uk","es-be","es-de","es-en","es-ru","es-uk","et-en","et-ru","fi-en","fi-ru","fr-be","fr-de","fr-en","fr-ru","fr-uk","hr-ru","hu-en","hu-ru","hy-ru","it-be","it-de","it-en","it-ru","it-uk","lt-en","lt-ru","lv-en","lv-ru","mk-en","mk-ru","nl-en","nl-ru","no-en","no-ru","pl-be","pl-ru","pl-uk","pt-en","pt-ru","ro-be","ro-ru","ro-uk","ru-az","ru-be","ru-bg","ru-ca","ru-cs","ru-da","ru-de","ru-el","ru-en","ru-es","ru-et","ru-fi","ru-fr","ru-hr","ru-hu","ru-hy","ru-it","ru-lt","ru-lv","ru-mk","ru-nl","ru-no","ru-pl","ru-pt","ru-ro","ru-sk","ru-sl","ru-sq","ru-sr","ru-sv","ru-tr","ru-uk","sk-en","sk-ru","sl-en","sl-ru","sq-en","sq-ru","sr-be","sr-ru","sr-uk","sv-en","sv-ru","tr-be","tr-de","tr-en","tr-ru","tr-uk","uk-bg","uk-cs","uk-de","uk-en","uk-es","uk-fr","uk-it","uk-pl","uk-ro","uk-ru","uk-sr","uk-tr"]}'
+    http_version: 
+  recorded_at: Fri, 19 May 2017 10:25:21 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/accepts_options.yml
+++ b/spec/vcr/accepts_options.yml
@@ -1,0 +1,43 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://translate.yandex.net/api/v1.5/tr.json/translate
+    body:
+      encoding: UTF-8
+      string: text=Car&lang=ru&key=<YANDEX_API_KEY>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.2
+      Date:
+      - Fri, 19 May 2017 10:25:20 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '59'
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - timeout=120
+      X-Content-Type-Options:
+      - nosniff
+      Cache-Control:
+      - no-store
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJjb2RlIjoyMDAsImxhbmciOiJlbi1ydSIsInRleHQiOlsi0JDQstGC0L7QvNC+0LHQuNC70YwiXX0=
+    http_version: 
+  recorded_at: Fri, 19 May 2017 10:25:20 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/get_translated_pl_text.yml
+++ b/spec/vcr/get_translated_pl_text.yml
@@ -1,0 +1,43 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://translate.yandex.net/api/v1.5/tr.json/translate
+    body:
+      encoding: UTF-8
+      string: text=Car&lang=pl&key=<YANDEX_API_KEY>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.2
+      Date:
+      - Fri, 19 May 2017 10:25:19 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '48'
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - timeout=120
+      X-Content-Type-Options:
+      - nosniff
+      Cache-Control:
+      - no-store
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJjb2RlIjoyMDAsImxhbmciOiJlbi1wbCIsInRleHQiOlsiU2Ftb2Now7NkIl19
+    http_version: 
+  recorded_at: Fri, 19 May 2017 10:25:19 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/get_translated_ru_text.yml
+++ b/spec/vcr/get_translated_ru_text.yml
@@ -1,0 +1,43 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://translate.yandex.net/api/v1.5/tr.json/translate
+    body:
+      encoding: UTF-8
+      string: text=Car&lang=ru&key=<YANDEX_API_KEY>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.2
+      Date:
+      - Fri, 19 May 2017 10:25:18 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '59'
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - timeout=120
+      X-Content-Type-Options:
+      - nosniff
+      Cache-Control:
+      - no-store
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJjb2RlIjoyMDAsImxhbmciOiJlbi1ydSIsInRleHQiOlsi0JDQstGC0L7QvNC+0LHQuNC70YwiXX0=
+    http_version: 
+  recorded_at: Fri, 19 May 2017 10:25:18 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/wrong_api_key.yml
+++ b/spec/vcr/wrong_api_key.yml
@@ -1,0 +1,42 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://translate.yandex.net/api/v1.5/tr.json/translate
+    body:
+      encoding: UTF-8
+      string: text=Car&lang=en-ru&key=wrong_api_key
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Server:
+      - nginx/1.6.2
+      Date:
+      - Fri, 19 May 2017 10:25:20 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '43'
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - timeout=120
+      X-Content-Type-Options:
+      - nosniff
+      Cache-Control:
+      - no-store
+    body:
+      encoding: UTF-8
+      string: '{"code":401,"message":"API key is invalid"}'
+    http_version: 
+  recorded_at: Fri, 19 May 2017 10:25:20 GMT
+recorded_with: VCR 3.0.3

--- a/yandex-translator.gemspec
+++ b/yandex-translator.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'httparty', '>= 0.13.4'
   gem.add_development_dependency 'rspec', '~> 3.1'
   gem.add_development_dependency 'webmock'
+  gem.add_development_dependency 'vcr'
 
   gem.files         = `git ls-files`.split($/)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }


### PR DESCRIPTION
Hi @aegorov,

This is a fix for error Encoding::CompatibilityError: incompatible encoding regexp match (UTF-8 regexp with ASCII-8BIT string). 
I encountered it when I wanted to translate text that includes special characters.

`translator.translate 'Car', from: 'ru'`
=>
`Encoding::CompatibilityError: incompatible encoding regexp match (UTF-8 regexp with ASCII-8BIT string) from ../ruby-2.4.0/gems/httparty-0.15.3/lib/httparty/parser.rb:120:ingsub`

According to @ericgj from [https://github.com/jnunemaker/httparty/issues/75](https://github.com/jnunemaker/httparty/issues/75) I've changed default httparty's parser, that fixed this problem.

In order to test request with vcr gem, I've created a new spec file called translator_vcr_spec.rb. 
In my test, request requires real api_key, so once you'll get it, create a file spec/secrets.yml, and put it there: 
`yandex_translator_api_key: your_api_key`
This pull request also includes vcr's cassets files, they are inside spec/vcr folder.
